### PR TITLE
Add support for `region` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Returns a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
   :--|:--|:--
   `client` | [Client ID](https://developers.google.com/maps/documentation/javascript/get-api-key#specify-a-client-id-when-loading-the-api) | `undefined`
   `key` | [Your API key](https://developers.google.com/maps/documentation/javascript/get-api-key#specify-a-key-when-loading-the-api) | `undefined`
-  `language` | [Language](https://developers.google.com/maps/documentation/javascript/examples/map-rtl) | `undefined`
+  `language` | [Language](https://developers.google.com/maps/documentation/javascript/localization#Language) | `undefined`
+  `region` | [Region](https://developers.google.com/maps/documentation/javascript/localization#Region) | `undefined`
   `libraries` | [Supplemental libraries to load](https://developers.google.com/maps/documentation/javascript/libraries) | `[]`
   `timeout` | Time in milliseconds before rejecting the promise | `10000`
   `v` | [API version](https://developers.google.com/maps/documentation/javascript/versions) | `undefined`

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ export default ({
   client,
   key,
   language,
+  region,
   libraries = [],
   timeout = 10000,
   v
@@ -22,6 +23,7 @@ export default ({
     if (client) params.push(`client=${client}`);
     if (key) params.push(`key=${key}`);
     if (language) params.push(`language=${language}`);
+    if (region) params.push(`region=${region}`);
     libraries = [].concat(libraries); // Ensure that `libraries` is an array
     if (libraries.length) params.push(`libraries=${libraries.join(',')}`);
     if (v) params.push(`v=${v}`);


### PR DESCRIPTION
Google Maps supports a region specifier, eg. for `en_GB` or `de_AT`, which is currently not supported.