### PR TITLE
Add caching of google maps instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+let googleMaps;
+
 export default ({
   client,
   key,
@@ -7,6 +9,9 @@ export default ({
   timeout = 10000,
   v
 } = {}) => {
+  if (googleMaps) {
+    return Promise.resolve(googleMaps);
+  }
 
   const callbackName = '__googleMapsApiOnLoadCallback';
 
@@ -43,6 +48,9 @@ export default ({
       if (timeoutId !== null) {
         clearTimeout(timeoutId);
       }
+
+      googleMaps = window.google.maps;
+
       resolve(window.google.maps);
       delete window[callbackName];
     };


### PR DESCRIPTION
I currently have the case where I call `loadGoogleMapsAPI` on a component level. If the component exists multiple times, lgma will try to add multiple script tags to the page, which the google maps api doesn't seem to like.

Thus I've added a very simple layer of caching to prevent that problem from happening.